### PR TITLE
Fix IndexError from deleting the only save file.

### DIFF
--- a/ardentryst.py
+++ b/ardentryst.py
@@ -1432,7 +1432,10 @@ def Game_SlotMenu(gameobj = None):
                         cursloaded = False
                         incompat = False
                 elif k == K_DELETE and pygame.key.get_mods() & KMOD_SHIFT:
-                    if gamelist[cursor]:
+                    if not len(gamelist):
+                        instructions = "There is no save file to delete."
+                        interface_sound("error")
+                    elif gamelist[cursor]:
                         interface_sound("menu-select")
                         os.remove(os.path.join(SAVEDIRECTORY, "Saves", gamelist[cursor]))
                         gamelist = [x for x in os.listdir(os.path.join(SAVEDIRECTORY, "Saves")) if x.endswith(".asf")]
@@ -1558,7 +1561,8 @@ def Game_SlotMenu(gameobj = None):
         tick += 1
         lasttick = wait_tick(lasttick)
 
-        if not newgame and not cursloaded:
+        # if gamelist is empty, we don't have a save to load
+        if len(gamelist) and not newgame and not cursloaded:
             gameobj = pickle.load(open(os.path.join(SAVEDIRECTORY, "Saves", gamelist[cursor]),"rb"))
             cursloaded = True
 


### PR DESCRIPTION
When there is only one save file in Resume Quest menu, deleting it causes an `IndexError: list index out of range` because it was accessing the -1th element of the zero-length array `gamelist` at [ardentryst.py:1562](https://github.com/ardentryst/ardentryst/blob/a135dba8b3dae9c6c6c823b0dfeda57741918650/ardentryst.py#L1562). 
```python
1562            gameobj = pickle.load(open(os.path.join(SAVEDIRECTORY, "Saves", gamelist[cursor]),"rb"))
```
After adding a check for `len(gamelist)`, Ardentryst encounters another IndexError if I press Shift-Delete again after deleting the only save. This IndexError happens in another place in the same function, line [1435](https://github.com/ardentryst/ardentryst/blob/a135dba8b3dae9c6c6c823b0dfeda57741918650/ardentryst.py#L1435). Adding a second check on the size of the list fixes that error also.
```python
1435                     if gamelist[cursor]:
```
Fixes #23.